### PR TITLE
fix: CVE-2023-38545 curl vulnerability [INS-3204]

### DIFF
--- a/.github/workflows/build-and-release.yaml
+++ b/.github/workflows/build-and-release.yaml
@@ -27,7 +27,7 @@ jobs:
           - macos-latest
           - ubuntu-latest
         libcurl-release:
-          - 7.79.1
+          - 8.4.0
         node-libcurl-cpp-std:
           - c++17
         node:
@@ -107,7 +107,7 @@ jobs:
           - macos-latest
           - ubuntu-latest
         libcurl-release:
-          - 7.79.1
+          - 8.4.0
         node:
           - 18.16.1
         electron-version:

--- a/.github/workflows/build-and-release.yaml
+++ b/.github/workflows/build-and-release.yaml
@@ -25,7 +25,6 @@ jobs:
       matrix:
         os:
           - macos-latest-large
-          - macos-latest-xlarge
           - ubuntu-latest
         libcurl-release:
           - 8.4.0
@@ -106,7 +105,6 @@ jobs:
       matrix:
         os:
           - macos-latest-large
-          - macos-latest-xlarge
           - ubuntu-latest
         libcurl-release:
           - 8.4.0

--- a/.github/workflows/build-and-release.yaml
+++ b/.github/workflows/build-and-release.yaml
@@ -24,7 +24,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - macos-latest-large
+          - macos-latest
           - ubuntu-latest
         libcurl-release:
           - 8.4.0
@@ -104,7 +104,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - macos-latest-large
+          - macos-latest
           - ubuntu-latest
         libcurl-release:
           - 8.4.0

--- a/.github/workflows/build-and-release.yaml
+++ b/.github/workflows/build-and-release.yaml
@@ -24,7 +24,8 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - macos-latest
+          - macos-latest-large
+          - macos-latest-xlarge
           - ubuntu-latest
         libcurl-release:
           - 8.4.0
@@ -104,7 +105,8 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - macos-latest
+          - macos-latest-large
+          - macos-latest-xlarge
           - ubuntu-latest
         libcurl-release:
           - 8.4.0

--- a/.github/workflows/build-lint-test.yaml
+++ b/.github/workflows/build-lint-test.yaml
@@ -22,7 +22,7 @@ jobs:
           - macos-latest
           - ubuntu-latest
         libcurl-release:
-          - 7.79.1
+          - 8.4.0
         node-libcurl-cpp-std:
           - c++17
         node:
@@ -32,7 +32,7 @@ jobs:
           - os: ubuntu-latest
             node: 18.16.1
             node-libcurl-cpp-std: c++17
-            libcurl-release: 7.79.1
+            libcurl-release: 8.4.0
             run-lint-and-tsc: true
 
     env:
@@ -142,7 +142,7 @@ jobs:
           - macos-latest
           - ubuntu-latest
         libcurl-release:
-          - 7.79.1
+          - 8.4.0
         node:
           - 18.16.1
         electron-version:

--- a/.github/workflows/build-lint-test.yaml
+++ b/.github/workflows/build-lint-test.yaml
@@ -19,7 +19,8 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - macos-latest
+          - macos-latest-large
+          - macos-latest-xlarge
           - ubuntu-latest
         libcurl-release:
           - 8.4.0
@@ -139,7 +140,8 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - macos-latest
+          - macos-latest-large
+          - macos-latest-xlarge
           - ubuntu-latest
         libcurl-release:
           - 8.4.0

--- a/.github/workflows/build-lint-test.yaml
+++ b/.github/workflows/build-lint-test.yaml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - macos-latest-large
+          - macos-latest
           - ubuntu-latest
         libcurl-release:
           - 8.4.0
@@ -139,7 +139,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - macos-latest-large
+          - macos-latest
           - ubuntu-latest
         libcurl-release:
           - 8.4.0

--- a/.github/workflows/build-lint-test.yaml
+++ b/.github/workflows/build-lint-test.yaml
@@ -20,7 +20,6 @@ jobs:
       matrix:
         os:
           - macos-latest-large
-          - macos-latest-xlarge
           - ubuntu-latest
         libcurl-release:
           - 8.4.0
@@ -141,7 +140,6 @@ jobs:
       matrix:
         os:
           - macos-latest-large
-          - macos-latest-xlarge
           - ubuntu-latest
         libcurl-release:
           - 8.4.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getinsomnia/node-libcurl",
-  "version": "2.3.6-19",
+  "version": "2.3.6-20",
   "description": "The fastest http(s) client (and much more) for Node.js - Node.js bindings for libcurl",
   "keywords": [
     "node-curl",

--- a/scripts/ci/build.sh
+++ b/scripts/ci/build.sh
@@ -176,7 +176,7 @@ fi
 ###################
 # Brotli version must match Node.js one
 # But brotli only started being shipped with Node 12
-BROTLI_NODEJS=$(node -e "console.log(process.versions.brotli || '')")
+# BROTLI_NODEJS=$(node -e "console.log(process.versions.brotli || '')")
 BROTLI_DEFAULT_RELEASE=${BROTLI_NODEJS:-1.0.9}
 BROTLI_RELEASE=${BROTLI_RELEASE:-$BROTLI_DEFAULT_RELEASE}
 BROTLI_DEST_FOLDER=$PREFIX_DIR/deps/brotli

--- a/scripts/ci/build.sh
+++ b/scripts/ci/build.sh
@@ -176,8 +176,8 @@ fi
 ###################
 # Brotli version must match Node.js one
 # But brotli only started being shipped with Node 12
-BROTLI_NODEJS=$(node -e "console.log(process.versions.brotli || '')")
-BROTLI_DEFAULT_RELEASE=${BROTLI_NODEJS:-1.0.7}
+# BROTLI_NODEJS=$(node -e "console.log(process.versions.brotli || '')")
+BROTLI_DEFAULT_RELEASE=${BROTLI_NODEJS:-1.0.9}
 BROTLI_RELEASE=${BROTLI_RELEASE:-$BROTLI_DEFAULT_RELEASE}
 BROTLI_DEST_FOLDER=$PREFIX_DIR/deps/brotli
 echo "Building brotli v$BROTLI_RELEASE"

--- a/scripts/ci/build.sh
+++ b/scripts/ci/build.sh
@@ -210,7 +210,7 @@ ls -al $ZSTD_BUILD_FOLDER/lib
 ###################
 # Build libssh2
 ###################
-LIBSSH2_RELEASE=${LIBSSH2_RELEASE:-1.10.0}
+LIBSSH2_RELEASE=${LIBSSH2_RELEASE:-1.11.0}
 LIBSSH2_DEST_FOLDER=$PREFIX_DIR/deps/libssh2
 echo "Building libssh2 v$LIBSSH2_RELEASE"
 ./scripts/ci/build-libssh2.sh $LIBSSH2_RELEASE $LIBSSH2_DEST_FOLDER >$LOGS_FOLDER/build-libssh2.log 2>&1

--- a/scripts/ci/build.sh
+++ b/scripts/ci/build.sh
@@ -176,7 +176,7 @@ fi
 ###################
 # Brotli version must match Node.js one
 # But brotli only started being shipped with Node 12
-# BROTLI_NODEJS=$(node -e "console.log(process.versions.brotli || '')")
+BROTLI_NODEJS=$(node -e "console.log(process.versions.brotli || '')")
 BROTLI_DEFAULT_RELEASE=${BROTLI_NODEJS:-1.0.9}
 BROTLI_RELEASE=${BROTLI_RELEASE:-$BROTLI_DEFAULT_RELEASE}
 BROTLI_DEST_FOLDER=$PREFIX_DIR/deps/brotli


### PR DESCRIPTION
Bump `libcurl` to 8.4.0, force `libssh2` to 1.11, `brotli` to 1.0.9

Released in `2.3.6-20`

Related to INS-3204, requires a new node-libcurl release
- https://jfrog.com/blog/curl-libcurl-october-2023-vulns-all-you-need-to-know/
- https://github.com/curl/curl/discussions/12026
- https://daniel.haxx.se/blog/2023/10/11/how-i-made-a-heap-overflow-in-curl/
