### PR TITLE
chore: update libcurl to 8.5.0 [n/a]

### DIFF
--- a/.github/workflows/build-and-release.yaml
+++ b/.github/workflows/build-and-release.yaml
@@ -49,7 +49,7 @@ jobs:
           - macos-latest
           - ubuntu-latest
         libcurl-release:
-          - 7.79.1
+          - 8.5.0
         node-libcurl-cpp-std:
           - c++17
         node:
@@ -108,7 +108,7 @@ jobs:
           - macos-latest
           - ubuntu-latest
         libcurl-release:
-          - 7.79.1
+          - 8.5.0
         node:
           - 20.9.0
         electron-version:

--- a/.github/workflows/build-lint-test.yaml
+++ b/.github/workflows/build-lint-test.yaml
@@ -43,7 +43,7 @@ jobs:
           - macos-latest
           - ubuntu-latest
         libcurl-release:
-          - 7.79.1
+          - 8.5.0
         node-libcurl-cpp-std:
           - c++17
         node:
@@ -53,7 +53,7 @@ jobs:
           - os: ubuntu-latest
             node: 20.9.0
             node-libcurl-cpp-std: c++17
-            libcurl-release: 7.79.1
+            libcurl-release: 8.5.0
             run-lint-and-tsc: true
 
     env:
@@ -141,7 +141,7 @@ jobs:
           - macos-latest
           - ubuntu-latest
         libcurl-release:
-          - 7.79.1
+          - 8.5.0
         node:
           - 20.9.0
         electron-version:


### PR DESCRIPTION
This PR aims to solve a dependency versioning problem we currently have.

It's not assigned to an issue on Linear, but we have spotted this problem while working on [INS-3359](https://linear.app/insomnia/issue/INS-3359/ssl-cert-validation)

- insomnia on develop uses our - 2.3.6-21  node-libcurl release which does **not** use the 8.4.0 libcurl, uses the 7.79.1 🛑 
- the only release we had supporting libcurl with 8.4.0 is our node-libcurl of 2.3.6-20 🛑 


In this PR - we bump Libcurl dependency to [8.5.0](https://github.com/curl/curl/releases/tag/curl-8_5_0). This node-libcurl build is available to test/debug on https://github.com/Kong/node-libcurl/releases/tag/v2.4.1-2


cc @jackkav if this is all green, it should be safe to merge to develop, and no need to re-tag/re-release -as it's available on [2.4.1-2](https://github.com/Kong/node-libcurl/releases/tag/v2.4.1-2)