### PR TITLE
Fix: build libcurl with `--with-secure-transport` on macOS [INS-3359]

### DIFF
--- a/.github/workflows/build-and-release.yaml
+++ b/.github/workflows/build-and-release.yaml
@@ -89,6 +89,7 @@ jobs:
         run: echo "GIT_TAG=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
       - name: "Publish Binary"
         run: |
+          pip install setuptools
           GIT_COMMIT=${{ github.sha }} GIT_TAG=$GIT_TAG RUNNER_OS=${{ runner.os }} ./scripts/ci/build.sh
       - name: Upload artifacts
         if: always()
@@ -177,6 +178,7 @@ jobs:
         run: echo "GIT_TAG=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
       - name: "Publish Binary"
         run: |
+          pip install setuptools
           GIT_COMMIT=${{ github.sha }} GIT_TAG=$GIT_TAG ./scripts/ci/build.sh
       - name: Upload artifacts
         if: always()
@@ -225,6 +227,7 @@ jobs:
       - name: Publish binary
         if: startsWith(github.ref, 'refs/tags/')
         run: |
+          pip install setuptools
           yarn node-pre-gyp package testpackage --verbose
           node scripts\module-packaging.js --publish $(yarn -s node-pre-gyp reveal staged_tarball --silent)
 
@@ -273,5 +276,6 @@ jobs:
       - name: Publish binary
         if: startsWith(github.ref, 'refs/tags/')
         run: |
+          pip install setuptools
           yarn node-pre-gyp package testpackage --verbose
           node scripts\module-packaging.js --publish $(yarn -s node-pre-gyp reveal staged_tarball --silent)

--- a/.github/workflows/build-and-release.yaml
+++ b/.github/workflows/build-and-release.yaml
@@ -8,7 +8,7 @@ name: build-and-release
 on:
   push:
     tags:
-      - '*'
+      - "*"
     branches:
       - develop
 
@@ -84,12 +84,12 @@ jobs:
           key: v4-${{ runner.os }}-libcurl-deps-cache-node-${{ matrix.node }}-fork
           restore-keys: |
             v4-${{ runner.os }}-libcurl-deps-cache-node-${{ matrix.node }}-fork
-      - name: 'Set GIT_TAG'
+      - name: "Set GIT_TAG"
         if: startsWith(github.ref, 'refs/tags')
         run: echo "GIT_TAG=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
-      - name: 'Publish Binary'
+      - name: "Publish Binary"
         run: |
-          GIT_COMMIT=${{ github.sha }} GIT_TAG=$GIT_TAG ./scripts/ci/build.sh
+          GIT_COMMIT=${{ github.sha }} GIT_TAG=$GIT_TAG RUNNER_OS=${{ runner.os }} ./scripts/ci/build.sh
       - name: Upload artifacts
         if: always()
         uses: actions/upload-artifact@v3
@@ -172,10 +172,10 @@ jobs:
           key: v4-${{ runner.os }}-libcurl-deps-cache-electron-${{ matrix.electron-version }}-fork
           restore-keys: |
             v4-${{ runner.os }}-libcurl-deps-cache-electron-${{ matrix.electron-version }}-fork
-      - name: 'Set GIT_TAG'
+      - name: "Set GIT_TAG"
         if: startsWith(github.ref, 'refs/tags')
         run: echo "GIT_TAG=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
-      - name: 'Publish Binary'
+      - name: "Publish Binary"
         run: |
           GIT_COMMIT=${{ github.sha }} GIT_TAG=$GIT_TAG ./scripts/ci/build.sh
       - name: Upload artifacts
@@ -241,8 +241,8 @@ jobs:
       ELECTRON_VERSION: ${{ matrix.electron-version }}
       npm_config_msvs_version: 2022
       npm_config_build_from_source: true
-      npm_config_runtime: 'electron'
-      npm_config_dist_url: 'https://electronjs.org/headers'
+      npm_config_runtime: "electron"
+      npm_config_dist_url: "https://electronjs.org/headers"
       npm_config_target: ${{ matrix.electron-version }}
     steps:
       - name: Checkout

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getinsomnia/node-libcurl",
-  "version": "2.3.6-21",
+  "version": "2.4.1-4",
   "description": "The fastest http(s) client (and much more) for Node.js - Node.js bindings for libcurl",
   "keywords": [
     "node-curl",

--- a/scripts/ci/build-libcurl.sh
+++ b/scripts/ci/build-libcurl.sh
@@ -134,7 +134,9 @@ fi
 #####
 # ssl
 ####
-if [ ! -z "$OPENSSL_BUILD_FOLDER" ]; then
+if [ "${RUNNER_OS}" == "macOS" ]; then
+  libcurl_args+=("--with-secure-transport")
+elif [ ! -z "$OPENSSL_BUILD_FOLDER" ]; then
   CPPFLAGS="$CPPFLAGS -I$OPENSSL_BUILD_FOLDER/include"
   LDFLAGS="$LDFLAGS -L$OPENSSL_BUILD_FOLDER/lib -Wl,-rpath,$OPENSSL_BUILD_FOLDER/lib"
 


### PR DESCRIPTION
1. This PR is to fix the issue [2255](https://github.com/Kong/insomnia/issues/2255).
2. The reason why it happens on macOS is that we are using `OpenSSL` as the implementation of TLS for all OS, but it will fail to read the keychain on macOS. 
3. `SecureTransport` is the native implementation of TLS on macOS, so we should build `libcurl` with the `--with-secure-transport` option.
4. Only more thing I need to verify is whether it happens on Windows or not.