### PR TITLE
fix(curl): revert to use openssl on macos [INS-3445]

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getinsomnia/node-libcurl",
-  "version": "2.4.1-5",
+  "version": "2.4.1-7",
   "description": "The fastest http(s) client (and much more) for Node.js - Node.js bindings for libcurl",
   "keywords": [
     "node-curl",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getinsomnia/node-libcurl",
-  "version": "2.4.1-7",
+  "version": "2.4.1-9",
   "description": "The fastest http(s) client (and much more) for Node.js - Node.js bindings for libcurl",
   "keywords": [
     "node-curl",

--- a/scripts/ci/build-libcurl.sh
+++ b/scripts/ci/build-libcurl.sh
@@ -15,6 +15,11 @@ mkdir -p $2/source
 FORCE_REBUILD=${FORCE_REBUILD:-}
 FORCE_REBUILD_LIBCURL=${FORCE_REBUILD_LIBCURL:-}
 
+# @TODO force rebuild on macOS, remove this later
+if [ "${RUNNER_OS}" == "macOS" ]; then
+  FORCE_REBUILD_LIBCURL="true"
+fi
+
 # @TODO We are explicitly checking the static lib
 if [[ -f $build_folder/lib/libcurl.a ]] && [[ -z $FORCE_REBUILD || $FORCE_REBUILD != "true" ]] && [[ -z $FORCE_REBUILD_LIBCURL || $FORCE_REBUILD_LIBCURL != "true" ]]; then
   echo "Skipping rebuild of libcurl because lib file already exists"

--- a/scripts/ci/build-libcurl.sh
+++ b/scripts/ci/build-libcurl.sh
@@ -134,9 +134,7 @@ fi
 #####
 # ssl
 ####
-if [ "${RUNNER_OS}" == "macOS" ]; then
-  libcurl_args+=("--with-secure-transport")
-elif [ ! -z "$OPENSSL_BUILD_FOLDER" ]; then
+if [ ! -z "$OPENSSL_BUILD_FOLDER" ]; then
   CPPFLAGS="$CPPFLAGS -I$OPENSSL_BUILD_FOLDER/include"
   LDFLAGS="$LDFLAGS -L$OPENSSL_BUILD_FOLDER/lib -Wl,-rpath,$OPENSSL_BUILD_FOLDER/lib"
 


### PR DESCRIPTION
We changed to use SecureTransport in the last release to access the keychain on macOS.

But it causes some regressions:
1. [#6948](https://github.com/Kong/insomnia/issues/6948)
2. [#6946](https://github.com/Kong/insomnia/issues/6946)

Using SecureTransport allows us to support Mac Keychain but we lose support for TLS 1.3 and client certificates cannot be directly uploaded into the app.

Using other solutions like OpenSSL, allows us to support TLS 1.3 and client certificates in the app, but we lose access to the MacOS Keychain.

But MacOS Keychain certificates could be imported into Insomnia if we supported OpenSSL (you would have them in two places, Insomnia + Keychain).

So the best solution is to support OpenSSL, and ask the user to re-import the client certificates they want to use inside Insomnia. We lose a native integration with Keychain, which will cause poor UX, but will not cause a loss of capability. Whereas supporting SecureTransport has better UX, but at a greater cost of loss of capability.