### PR TITLE
feat(ci/SEC-1085): slsa sbom and provenance generation

### DIFF
--- a/.github/workflows/build-and-release.yaml
+++ b/.github/workflows/build-and-release.yaml
@@ -62,25 +62,13 @@ jobs:
     steps:
       - if: runner.os == 'macOS'
         name: Install Needed packages on macOS
-        run: brew install coreutils wget automake libtool cmake gnu-sed m4
-      # not using brew for that one as we need 2.69
-      - if: runner.os == 'macOS'
-        name: Install autoconf
-        run: |
-          curl -O -L http://ftpmirror.gnu.org/autoconf/autoconf-2.69.tar.gz
-          tar -xzf autoconf-2.69.tar.gz
-          cd autoconf-*
-          ./configure
-          make
-          make install
-          autoconf --version
-          ln -s /usr/local/bin/glibtoolize /usr/local/bin/libtoolize
+        run: brew install coreutils wget automake libtool cmake gnu-sed m4 autoconf@2.69 groff
       - if: runner.os == 'Linux'
         name: Install Needed packages on Linux
         run: sudo apt-get install -y cmake
       - name: Checkout
         uses: actions/checkout@v3
-      - name: Setup Node.js ${{ matrix.node }}
+      - name: Setup Node
         uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node }}
@@ -143,19 +131,7 @@ jobs:
     steps:
       - if: runner.os == 'macOS'
         name: Install Needed packages
-        run: brew install coreutils wget automake libtool cmake gnu-sed m4
-      # not using brew for that one as we need 2.69
-      - if: runner.os == 'macOS'
-        name: Install autoconf
-        run: |
-          curl -O -L http://ftpmirror.gnu.org/autoconf/autoconf-2.69.tar.gz
-          tar -xzf autoconf-2.69.tar.gz
-          cd autoconf-*
-          ./configure
-          make
-          make install
-          autoconf --version
-          ln -s /usr/local/bin/glibtoolize /usr/local/bin/libtoolize
+        run: brew install coreutils wget automake libtool cmake gnu-sed m4 autoconf@2.69 groff
       - if: runner.os == 'Linux'
         name: Install Needed packages on Linux
         run: sudo apt-get install -y cmake

--- a/.github/workflows/build-and-release.yaml
+++ b/.github/workflows/build-and-release.yaml
@@ -18,6 +18,28 @@ env:
 # all jobs here must have a matrix identical to the ones inside build-lint-test.yaml
 
 jobs:
+  scan:
+    permissions:
+      packages: write
+      contents: write # publish sbom to GH releases/tag assets
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          path: ${{ github.repository }}
+
+      # Perform SCA analysis for the code repository
+      # Produces SBOM and CVE report
+      # Helps understand vulnerabilities / license compliance across third party dependencies
+      # Drift: Doesn't track any yarn global or OS specific packages that involves scanning entire root file system.
+      # (TODO): Produce OS specific SBOM to detect build time depdencies. 
+      - id: sca-project
+        uses: Kong/public-shared-actions/security-actions/sca@2f02738ecb1670f01391162e43fe3f5d4e7942a1 # v2.2.2
+        with:
+          dir: ${{ github.repository }}
+          upload-sbom-release-assets: true
+      
   build-and-release-nodejs:
     runs-on: ${{ matrix.os }}
     strategy:
@@ -180,6 +202,7 @@ jobs:
         run: |
           pip install packaging
           GIT_COMMIT=${{ github.sha }} GIT_TAG=$GIT_TAG ./scripts/ci/build.sh
+          # Perform SCA analysis for the code repository
       - name: Upload artifacts
         if: always()
         uses: actions/upload-artifact@v3
@@ -279,3 +302,4 @@ jobs:
           pip install packaging
           yarn node-pre-gyp package testpackage --verbose
           node scripts\module-packaging.js --publish $(yarn -s node-pre-gyp reveal staged_tarball --silent)
+          

--- a/.github/workflows/build-lint-test.yaml
+++ b/.github/workflows/build-lint-test.yaml
@@ -13,6 +13,27 @@ concurrency:
 # all jobs here must have a matrix identical to the ones inside build-and-release.yaml
 
 jobs:
+  scan:
+    permissions:
+      packages: write
+      contents: write # publish sbom to GH releases/tag assets
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          path: ${{ github.repository }}
+
+      # Perform SCA analysis for the code repository
+      # Produces SBOM and CVE report
+      # Helps understand vulnerabilities / license compliance across third party dependencies
+      # Drift: Doesn't track any yarn global or OS specific packages that involves scanning entire root file system.
+      # (TODO): Produce OS specific SBOM to detect build time depdencies. 
+      - id: sca-project
+        uses: Kong/public-shared-actions/security-actions/sca@2f02738ecb1670f01391162e43fe3f5d4e7942a1 # v2.2.2
+        with:
+          dir: ${{ github.repository }}
+
   build-and-test-nodejs:
     runs-on: ${{ matrix.os }}
     strategy:
@@ -54,19 +75,7 @@ jobs:
         run: cat run_result 2>/dev/null || echo 'default'
       - if: runner.os == 'macOS'
         name: Install Needed packages on macOS
-        run: brew install coreutils wget automake libtool cmake gnu-sed m4
-      # not using brew for that one as we need 2.69
-      - if: runner.os == 'macOS'
-        name: Install autoconf
-        run: |
-          curl -O -L http://ftpmirror.gnu.org/autoconf/autoconf-2.69.tar.gz
-          tar -xzf autoconf-2.69.tar.gz
-          cd autoconf-*
-          ./configure
-          make
-          make install
-          autoconf --version
-          ln -s /usr/local/bin/glibtoolize /usr/local/bin/libtoolize
+        run: brew install coreutils wget automake libtool cmake gnu-sed m4 autoconf@2.69 groff
       - if: runner.os == 'Linux'
         name: Install Needed packages on Linux
         run: sudo apt-get install -y cmake
@@ -169,19 +178,7 @@ jobs:
         id: set-up-homebrew
         uses: Homebrew/actions/setup-homebrew@master
       - name: Install Needed packages
-        run: brew install coreutils wget automake libtool cmake gnu-sed m4
-      # not using brew for that one as we need 2.69
-      - if: runner.os == 'macOS'
-        name: Install autoconf
-        run: |
-          curl -O -L http://ftpmirror.gnu.org/autoconf/autoconf-2.69.tar.gz
-          tar -xzf autoconf-2.69.tar.gz
-          cd autoconf-*
-          ./configure
-          make
-          make install
-          autoconf --version
-          ln -s /usr/local/bin/glibtoolize /usr/local/bin/libtoolize
+        run: brew install coreutils wget automake libtool cmake gnu-sed m4 autoconf@2.69 groff
       - name: Checkout
         uses: actions/checkout@v3
       - name: Setup Node.js ${{ matrix.node }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -9,12 +9,14 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     permissions:
-      contents: read
-      packages: write
+      contents: write
+      id-token: write # For using token to sign images
+      actions: read # For getting workflow run info to build provenance
+      packages: write # Required for publishing provenance. Issue: https://github.com/slsa-framework/slsa-github-generator/tree/main/internal/builders/container#known-issues
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - name: Setup Node.js ${{ matrix.node }}
+      - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
           node-version: 20.9.0
@@ -24,6 +26,6 @@ jobs:
       - name: Build
         run: yarn build:dist
       - name: Publish Package
-        run: yarn publish --access public
+        run: npm publish --access public --no-git-checks --provenance --tag ${{ github.sha }}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
###  Summary
- SBOM is produced by detecting any supported packages within the ${{github.repository}}. Ex: `yarn.lock`
- No Distro specific packages / deps are tracked in the SBOM
- Provenance is published using npm due to [issue #5430](https://github.com/yarnpkg/berry/issues/5430)

### TODO
- identify any drift for missing packages / libraries in the SBOM:
  - package managers
  -  source binaries 
  - yarn global cache
  - node-gyp
  - libcurl
- Refactor to storing build tooling in a directory relative to ${{github.repository}} for Syft catalogers to avoid parsing complete filesystem "\"

### References
- Refer https://github.com/anchore/syft/tree/main/syft/pkg/cataloger to understand how each cataloger parses / looks up for dependencies.