### PR TITLE
Change-versioning-again

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@getinsomnia/node-libcurl",
-  "version": "2.4.31-0",
+  "version": "2.31.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@getinsomnia/node-libcurl",
-      "version": "2.4.31-0",
+      "version": "2.31.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getinsomnia/node-libcurl",
-  "version": "2.4.31-0",
+  "version": "2.31.1",
   "description": "The fastest http(s) client (and much more) for Node.js - Node.js bindings for libcurl",
   "keywords": [
     "node-curl",


### PR DESCRIPTION
2.4.31-0 style has been used for a while to reflect that it was originally branches off of node-libcurl 2.4.x

when we publish tihngs by mistake we have been incrementing the -0 -1 part at the end to some sucess, but most recently it has been causing trouble. This is because we published a version at 2.4.31 which is broken and 2.3.31-0 which works and npm doesn't resolve it properly.

Therfore I propose we publish a version where the electron version in the major rather than the minor release, to avoid this going forward and rememdy the current state where cloning insomnia and running npm i will fail.