### PR TITLE
spike: try macos-13-xlarge

### DIFF
--- a/.github/workflows/build-and-release.yaml
+++ b/.github/workflows/build-and-release.yaml
@@ -46,7 +46,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - macos-13
+          - macos-13-xlarge
           - ubuntu-22.04
         libcurl-release:
           - 7.79.1
@@ -105,7 +105,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - macos-13
+          - macos-13-xlarge
           - ubuntu-22.04
         libcurl-release:
           - 7.79.1

--- a/.github/workflows/build-lint-test.yaml
+++ b/.github/workflows/build-lint-test.yaml
@@ -40,7 +40,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - macos-13
+          - macos-13-xlarge
           - ubuntu-22.04
         libcurl-release:
           - 7.79.1
@@ -138,7 +138,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - macos-13
+          - macos-13-xlarge
           - ubuntu-22.04
         libcurl-release:
           - 7.79.1


### PR DESCRIPTION
Trying `macos-13-xlarge` - basic one is taking almost 1hour

**Reduces build time to <16 mins**

Potencial problem - not sure if final builds are universal, or arm64  only and not x86_64 - we might want to use https://github.com/Kong/node-libcurl/pull/68 instead ?

we can check if we cut a test version from this PR

![image](https://github.com/user-attachments/assets/2db43e30-207d-412b-84bf-6de330f94b66)
![image](https://github.com/user-attachments/assets/9160948d-9ecc-4171-8c4e-25646270c829)
