### PR TITLE
spike: try macos-13-large

### DIFF
--- a/.github/workflows/build-and-release.yaml
+++ b/.github/workflows/build-and-release.yaml
@@ -46,7 +46,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - macos-13
+          - macos-13-large
           - ubuntu-22.04
         libcurl-release:
           - 7.79.1
@@ -105,7 +105,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - macos-13
+          - macos-13-large
           - ubuntu-22.04
         libcurl-release:
           - 7.79.1

--- a/.github/workflows/build-lint-test.yaml
+++ b/.github/workflows/build-lint-test.yaml
@@ -40,7 +40,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - macos-13
+          - macos-13-large
           - ubuntu-22.04
         libcurl-release:
           - 7.79.1
@@ -138,7 +138,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - macos-13
+          - macos-13-large
           - ubuntu-22.04
         libcurl-release:
           - 7.79.1


### PR DESCRIPTION
Trying `macos-13-large` - basic one is taking almost 1hour

**Reduces build time to < 30 mins**

![image](https://github.com/user-attachments/assets/51051330-87b7-43b2-970a-680e877e5d82)
![image](https://github.com/user-attachments/assets/7459f1ff-3bbd-43b3-8203-a1baf91e58a3)
