### PR TITLE
feat: enable legacy openssl providers + weak ciphers support

### DIFF
--- a/scripts/ci/build-openssl.sh
+++ b/scripts/ci/build-openssl.sh
@@ -57,7 +57,7 @@ if [ "$MACOS_UNIVERSAL_BUILD" == "true" ]; then
       -fPIC \
       --prefix=$build_folder \
       --openssldir=$build_folder \
-      no-tests no-shared "${@:2}"
+      no-tests no-shared enable-legacy "${@:2}"
 
     make && make install_sw
 
@@ -84,7 +84,7 @@ else
     -fPIC \
     --prefix=$build_folder \
     --openssldir=$build_folder \
-    no-shared "${@:3}"
+    no-shared enable-legacy "${@:3}"
 
   # Release - Both
   # ./config \

--- a/scripts/ci/build-openssl.sh
+++ b/scripts/ci/build-openssl.sh
@@ -57,7 +57,7 @@ if [ "$MACOS_UNIVERSAL_BUILD" == "true" ]; then
       -fPIC \
       --prefix=$build_folder \
       --openssldir=$build_folder \
-      no-tests no-shared enable-legacy "${@:2}"
+      no-tests no-shared enable-legacy enable-weak-ssl-ciphers "${@:2}"
 
     make && make install_sw
 
@@ -84,7 +84,7 @@ else
     -fPIC \
     --prefix=$build_folder \
     --openssldir=$build_folder \
-    no-shared enable-legacy "${@:3}"
+    no-shared enable-legacy enable-weak-ssl-ciphers "${@:3}"
 
   # Release - Both
   # ./config \


### PR DESCRIPTION
## Update: Reverted this commit - see `Note for posterity` on https://github.com/Kong/insomnia/pull/8192#issue-2680538708

## Update2: If we have a need for looking into this again, see about how we can enable legacy providers and weak ciphers here https://github.com/JCMais/curl-for-windows/tree/master/openssl  and if we need to fork that.


trying to fix https://github.com/Kong/insomnia/issues/5059 and other similar issues where folks use weak/deprecated/old ciphers

some investigation:
- https://github.com/openssl/openssl/discussions/21665
- https://docs.openssl.org/3.0/man1/openssl-ciphers/#cipher-strings  - [RC2 cipher](https://en.wikipedia.org/wiki/RC2#RC2-40) is old and weak and is not available by default
- tried to create old certificate with https://usercomp.com/news/1325946/creating-p12-rc2-40-cbc-certificate-with-openssl-3-2-1, not a lot of success yet