### PR TITLE
fix: localhost resolution RFC6761

### DIFF
--- a/.github/workflows/build-and-release.yaml
+++ b/.github/workflows/build-and-release.yaml
@@ -49,7 +49,7 @@ jobs:
           - macos-13-xlarge
           - ubuntu-22.04
         libcurl-release:
-          - 7.79.1
+          - 7.85.0
         node-libcurl-cpp-std:
           - c++17
         node:
@@ -108,7 +108,7 @@ jobs:
           - macos-13-xlarge
           - ubuntu-22.04
         libcurl-release:
-          - 7.79.1
+          - 7.85.0
         node:
           - 20.16.0
         electron-version:

--- a/.github/workflows/build-and-release.yaml
+++ b/.github/workflows/build-and-release.yaml
@@ -49,7 +49,7 @@ jobs:
           - macos-13-xlarge
           - ubuntu-22.04
         libcurl-release:
-          - 7.85.0
+          - 7.86.0
         node-libcurl-cpp-std:
           - c++17
         node:
@@ -108,7 +108,7 @@ jobs:
           - macos-13-xlarge
           - ubuntu-22.04
         libcurl-release:
-          - 7.85.0
+          - 7.86.0
         node:
           - 20.16.0
         electron-version:

--- a/.github/workflows/build-lint-test.yaml
+++ b/.github/workflows/build-lint-test.yaml
@@ -43,7 +43,7 @@ jobs:
           - macos-13-xlarge
           - ubuntu-22.04
         libcurl-release:
-          - 7.79.1
+          - 7.85.0
         node-libcurl-cpp-std:
           - c++17
         node:
@@ -53,7 +53,7 @@ jobs:
           - os: ubuntu-latest
             node: 20.16.0
             node-libcurl-cpp-std: c++17
-            libcurl-release: 7.79.1
+            libcurl-release: 7.85.0
             run-lint-and-tsc: true
 
     env:
@@ -141,7 +141,7 @@ jobs:
           - macos-13-xlarge
           - ubuntu-22.04
         libcurl-release:
-          - 7.79.1
+          - 7.85.0
         node:
           - 20.16.0
         electron-version:

--- a/.github/workflows/build-lint-test.yaml
+++ b/.github/workflows/build-lint-test.yaml
@@ -43,7 +43,7 @@ jobs:
           - macos-13-xlarge
           - ubuntu-22.04
         libcurl-release:
-          - 7.85.0
+          - 7.86.0
         node-libcurl-cpp-std:
           - c++17
         node:
@@ -53,7 +53,7 @@ jobs:
           - os: ubuntu-latest
             node: 20.16.0
             node-libcurl-cpp-std: c++17
-            libcurl-release: 7.85.0
+            libcurl-release: 7.86.0
             run-lint-and-tsc: true
 
     env:
@@ -141,7 +141,7 @@ jobs:
           - macos-13-xlarge
           - ubuntu-22.04
         libcurl-release:
-          - 7.85.0
+          - 7.86.0
         node:
           - 20.16.0
         electron-version:

--- a/test/curl/localhost.spec.ts
+++ b/test/curl/localhost.spec.ts
@@ -1,0 +1,69 @@
+import 'should'
+import { app, host, port, server } from '../helper/server'
+import { Curl } from '../../lib'
+
+let curl: Curl
+const urlLocalhost = `http://localhost:${port}/`
+const urlTestLocalhost = `http://test.localhost:${port}/`
+
+describe('DNS Resolution', () => {
+  before((done) => {
+    server.listen(port, host, () => done())
+
+    app.get('/', (req, res) => {
+      res.send({ message: 'resolved', ip: req.ip })
+    })
+  })
+
+  after((done) => {
+    server.close()
+    app._router.stack.pop()
+    done()
+  })
+
+  beforeEach(() => {
+    curl = new Curl()
+  })
+
+  afterEach(() => {
+    curl.close()
+  })
+
+  it('should resolve localhost to 127.0.0.1', (done) => {
+    curl.setOpt('URL', urlLocalhost)
+
+    curl.on('end', (status, data) => {
+      if (status !== 200) {
+        throw Error(`Invalid status code: ${status}`)
+      }
+
+      const result = JSON.parse(data as string)
+      result.message.should.be.equal('resolved')
+      result.ip.should.be.equal('::1')
+
+      done()
+    })
+
+    curl.on('error', done)
+    curl.perform()
+  })
+
+  it('should resolve test.localhost to 127.0.0.1', (done) => {
+    curl.setOpt('URL', urlTestLocalhost)
+
+    curl.on('end', (status, data) => {
+      if (status !== 200) {
+        throw Error(`Invalid status code: ${status}`)
+      }
+
+      const result = JSON.parse(data as string)
+      result.message.should.be.equal('resolved')
+      result.ip.should.be.equal('::1')
+
+      done()
+    })
+
+    curl.on('error', done)
+    curl.perform()
+  })
+})

--- a/test/curl/localhost.spec.ts
+++ b/test/curl/localhost.spec.ts
@@ -51,10 +51,10 @@ describe('DNS Resolution', () => {
   it('should resolve test.localhost to 127.0.0.1', (done) => {
     // skip this test if windows because it does not support *.localhost on hosts file?
     // https://stackoverflow.com/questions/138162/wildcards-in-a-windows-hosts-file/4166967#4166967
-    if (process.platform === 'win32') {
-      done()
-      return
-    }
+    // if (process.platform === 'win32') {
+    //   done()
+    //   return
+    // }
     curl.setOpt('URL', urlTestLocalhost)
 
     curl.on('end', (status, data) => {

--- a/test/curl/localhost.spec.ts
+++ b/test/curl/localhost.spec.ts
@@ -49,6 +49,12 @@ describe('DNS Resolution', () => {
   })
 
   it('should resolve test.localhost to 127.0.0.1', (done) => {
+    // skip this test if windows because it does not support *.localhost on hosts file?
+    // https://stackoverflow.com/questions/138162/wildcards-in-a-windows-hosts-file/4166967#4166967
+    if (process.platform === 'win32') {
+      done()
+      return
+    }
     curl.setOpt('URL', urlTestLocalhost)
 
     curl.on('end', (status, data) => {


### PR DESCRIPTION
Trying to investigate https://github.com/Kong/insomnia/issues/8160 and if it's potentially an issue on node-libcurl side

Bumps to libcurl `7.86.0` where the fix was introduced. Not bumping to any higher libcurl version for now to avoid dragons.

Research:
- https://github.com/curl/curl/commit/58d12921c93e2aac92fcec56e2be3ab475ffc6d5 (Fix was introduced here) - released in [curl 7.85.0](https://curl.se/changes.html#7_85_0)
- https://github.com/curl/curl/commit/b5c0fe20e370ea2e5791fce4cedb34a71bc784e5#diff-e0b647f3e21a7fb58400dcec74f381d2fe16ca41e983240c15fc1243c574dbf9R504
- https://stackoverflow.com/a/76432868
- https://daniel.haxx.se/blog/2021/05/31/curl-localhost-as-a-local-host/

Note: Windows still fails on the `test.localhost` scenario, even though using curl 7.85.0 on a Windows machine works, not sure what's the reason for it to fail here 🤷‍♂️  Looks like there's more weirdness there potentially. ⚠️ Update on windows: we're dependant on https://github.com/JCMais/curl-for-windows - the git submodule was pointing at an older commit. Regardless of version set on linux and macos. Latest commit on that repo has since pulled to curl 7.86.0