### PR TITLE
feat: enable-legacy and enable-weak-ssl-ciphers

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,5 +1,5 @@
 [submodule "deps/curl-for-windows"]
 	path = deps/curl-for-windows
-	url = https://github.com/JCMais/curl-for-windows.git
+	url = https://github.com/notjaywu/curl-for-windows.git
 	ignore = dirty
 	branch = master

--- a/scripts/ci/build-openssl.sh
+++ b/scripts/ci/build-openssl.sh
@@ -57,7 +57,7 @@ if [ "$MACOS_UNIVERSAL_BUILD" == "true" ]; then
       -fPIC \
       --prefix=$build_folder \
       --openssldir=$build_folder \
-      no-tests no-shared "${@:2}"
+      no-tests no-shared enable-legacy enable-weak-ssl-ciphers "${@:2}"
 
     make && make install_sw
 
@@ -84,7 +84,7 @@ else
     -fPIC \
     --prefix=$build_folder \
     --openssldir=$build_folder \
-    no-shared "${@:3}"
+    no-shared enable-legacy enable-weak-ssl-ciphers "${@:3}"
 
   # Release - Both
   # ./config \


### PR DESCRIPTION
Taking another pass at https://github.com/Kong/node-libcurl/pull/69, this time doing the change also on the curl-for-windows fork

Related to [INS-4508](https://linear.app/insomnia/issue/INS-4508)