### PR TITLE
chore: switch curl-for-windows fork

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,5 +1,5 @@
 [submodule "deps/curl-for-windows"]
 	path = deps/curl-for-windows
-	url = https://github.com/notjaywu/curl-for-windows.git
+	url = https://github.com/Kong/curl-for-windows.git
 	ignore = dirty
 	branch = master


### PR DESCRIPTION
Follow-up to https://github.com/Kong/node-libcurl/pull/71 - using Kong's fork, with updated openssl .cnf files to try to enable legacy providers