### PR TITLE
fix: nan-patch edit for insomnia repo

### DIFF
--- a/scripts/nan-patch.js
+++ b/scripts/nan-patch.js
@@ -2,6 +2,11 @@
 const path = require('path')
 const fs = require('fs')
 const filePath = path.join(__dirname, '../node_modules/nan/nan.h')
+// if file not found, exit script without error (e.g. running `npm i` in insomnia repository)
+if (!fs.existsSync(filePath)) {
+  console.log('nan.h not found, skipping patch')
+  process.exit(0)
+}
 const fileContent = fs.readFileSync(filePath, 'utf8')
 const updatedContent = fileContent.replace(
   /#include "nan_scriptorigin.h"/,


### PR DESCRIPTION
Fixes insomnia build issue
```
npm error Error: ENOENT: no such file or directory, open '/Users/runner/work/insomnia/insomnia/node_modules/@getinsomnia/node-libcurl/node_modules/nan/nan.h'
npm error     at Object.readFileSync (node:fs:448:20)
npm error     at Object.<anonymous> (/Users/runner/work/insomnia/insomnia/node_modules/@getinsomnia/node-libcurl/scripts/nan-patch.js:5:24)
npm error     at Module._compile (node:internal/modules/cjs/loader:1469:14)
npm error     at Module._extensions..js (node:internal/modules/cjs/loader:1548:10)
npm error     at Module.load (node:internal/modules/cjs/loader:1288:32)
npm error     at Module._load (node:internal/modules/cjs/loader:1104:12)
npm error     at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:174:12)
npm error     at node:internal/main/run_main_module:28:49 {
npm error   errno: -2,
npm error   code: 'ENOENT',
npm error   syscall: 'open',
npm error   path: '/Users/runner/work/insomnia/insomnia/node_modules/@getinsomnia/node-libcurl/node_modules/nan/nan.h'
npm error }
npm error
```