### PR TITLE
revert: enable-legacy and weak-ciphers

### DIFF
--- a/scripts/ci/build-openssl.sh
+++ b/scripts/ci/build-openssl.sh
@@ -57,7 +57,7 @@ if [ "$MACOS_UNIVERSAL_BUILD" == "true" ]; then
       -fPIC \
       --prefix=$build_folder \
       --openssldir=$build_folder \
-      no-tests no-shared enable-legacy enable-weak-ssl-ciphers "${@:2}"
+      no-tests no-shared "${@:2}"
 
     make && make install_sw
 
@@ -84,7 +84,7 @@ else
     -fPIC \
     --prefix=$build_folder \
     --openssldir=$build_folder \
-    no-shared enable-legacy enable-weak-ssl-ciphers "${@:3}"
+    no-shared "${@:3}"
 
   # Release - Both
   # ./config \


### PR DESCRIPTION
Reverts enable-legacy and weak-cipher flags for Linux, MacOS and Windows as it is potentially triggering the failing custom ca root certificate tests on insomnia.


Recommendation for supporting PKS12 RC2 cipher, would be to add a transform function to the content of the cetificate file before sending it to node-libcurl as supporting old ciphers like this is no longer a part of modern curl.