### PR TITLE
chore: run release workflows on aarch64 linux runner

### DIFF
--- a/.github/workflows/build-and-release.yaml
+++ b/.github/workflows/build-and-release.yaml
@@ -49,6 +49,7 @@ jobs:
         os:
           - macos-13-xlarge
           - ubuntu-22.04
+          - ubuntu-22.04-arm
         libcurl-release:
           - 7.86.0
         node-libcurl-cpp-std:
@@ -109,6 +110,7 @@ jobs:
         os:
           - macos-13-xlarge
           - ubuntu-22.04
+          - ubuntu-22.04-arm
         libcurl-release:
           - 7.86.0
         node:

--- a/.github/workflows/build-lint-test.yaml
+++ b/.github/workflows/build-lint-test.yaml
@@ -42,6 +42,7 @@ jobs:
         os:
           - macos-13-xlarge
           - ubuntu-22.04
+          - ubuntu-22.04-arm
         libcurl-release:
           - 7.86.0
         node-libcurl-cpp-std:
@@ -140,6 +141,7 @@ jobs:
         os:
           - macos-13-xlarge
           - ubuntu-22.04
+          - ubuntu-22.04-arm
         libcurl-release:
           - 7.86.0
         node:


### PR DESCRIPTION
Related to https://github.com/Kong/insomnia/pull/8306.