### PR TITLE
fix: use process.arch to determine default target arch

### DIFF
--- a/.github/workflows/build-and-release.yaml
+++ b/.github/workflows/build-and-release.yaml
@@ -95,7 +95,6 @@ jobs:
           GIT_COMMIT=${{ github.sha }} \
           GIT_TAG=$GIT_TAG \
           RUNNER_OS=${{ matrix.os }} \
-          TARGET_ARCH=${{ matrix.os=='ubuntu-22.04-arm' && 'arm64' || 'x64' }} \
           ./scripts/ci/build.sh
       - name: Upload artifacts
         if: always()
@@ -167,7 +166,6 @@ jobs:
           pip install packaging
           GIT_COMMIT=${{ github.sha }} \
           GIT_TAG=$GIT_TAG \
-          TARGET_ARCH=${{ matrix.os=='ubuntu-22.04-arm' && 'arm64' || 'x64' }} \
           ./scripts/ci/build.sh
       - name: Upload artifacts
         if: always()

--- a/.github/workflows/build-lint-test.yaml
+++ b/.github/workflows/build-lint-test.yaml
@@ -103,7 +103,6 @@ jobs:
           RUN_TESTS=false \
           RUN_PREGYP_CLEAN=false \
           PUBLISH_BINARY=false \
-          TARGET_ARCH=${{ matrix.os=='ubuntu-22.04-arm' && 'arm64' || 'x64' }} \
             ./scripts/ci/build.sh
       - name: 'Run lint'
         if: matrix.run-lint-and-tsc && steps.run_result.outputs.run_result != 'success'
@@ -209,7 +208,6 @@ jobs:
           RUN_TESTS=true \
           RUN_PREGYP_CLEAN=false \
           PUBLISH_BINARY=false \
-          TARGET_ARCH=${{ matrix.os=='ubuntu-22.04-arm' && 'arm64' || 'x64' }} \
             ./scripts/ci/build.sh
       - name: Upload artifacts
         if: always() && steps.run_result.outputs.run_result != 'success'

--- a/scripts/ci/build.sh
+++ b/scripts/ci/build.sh
@@ -61,7 +61,7 @@ LOGS_FOLDER=${BUILD_LOGS_FOLDER:-./logs}
 mkdir -p $LOGS_FOLDER
 
 # ia32, x64, armv7, etc
-target_arch=${TARGET_ARCH:-"x64"}
+target_arch=${TARGET_ARCH:-"$(node -e 'console.log(process.arch)')"}
 # the build system of some dependencies (e.g. zstd and openldap) seems to read
 # and use this variable, so unset it here to avoid making them fail
 unset TARGET_ARCH


### PR DESCRIPTION
Instead of setting `TARGET_ARCH` inside the workflow, use a better autodetection mechanism.