### PR TITLE
fix: Pin all external github actions to their corresponding commit SHAs

### DIFF
--- a/.github/workflows/build-lint-test.yaml
+++ b/.github/workflows/build-lint-test.yaml
@@ -117,7 +117,7 @@ jobs:
       # but coverage is only sent for the run-lint-and-tsc job
       - name: Upload coverage to Codecov
         if: matrix.run-lint-and-tsc && steps.run_result.outputs.run_result != 'success'
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@29386c70ef20e286228c72b668a06fd0e8399192 # v1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           file: ./coverage/**

--- a/.github/workflows/new-version.yml
+++ b/.github/workflows/new-version.yml
@@ -23,7 +23,7 @@ jobs:
           token: ${{ secrets.PAT_INSOMNIA_INFRA }}
 
       - name: Configure Git user
-        uses: Homebrew/actions/git-user-config@master
+        uses: Homebrew/actions/git-user-config@266845213695c3047d210b2e8fbc42ecdaf45802 # master
         with:
           username: ${{ (github.event_name == 'workflow_dispatch' && github.actor) || 'insomnia-infra' }}
 
@@ -49,7 +49,7 @@ jobs:
           git push origin develop
 
       - name: Create Tag and Release
-        uses: ncipollo/release-action@v1
+        uses: ncipollo/release-action@440c8c1cb0ed28b9f43e4d1d670870f059653174 # v1
         id: core_tag_and_release
         with:
           tag: v${{ env.TAG }}


### PR DESCRIPTION
Replace branch reference with commit SHA for external github actions