### PR TITLE
fix: force ipv6 support

### DIFF
--- a/scripts/ci/build-libcurl.sh
+++ b/scripts/ci/build-libcurl.sh
@@ -272,6 +272,7 @@ export LDFLAGS=$LDFLAGS
 
 # Release - Static
 ./configure \
+    --enable-ipv6 \
     --without-nss \
     --without-libpsl \
     --without-librtmp \


### PR DESCRIPTION
The last build somehow dropped `IPv6` support, this re-enables it